### PR TITLE
Add docblock information to contributions guide

### DIFF
--- a/contributions.md
+++ b/contributions.md
@@ -52,3 +52,22 @@ If you discover a security vulnerability within Laravel, please send an e-mail t
 ## Coding Style
 
 Laravel follows the [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md) coding standard and the [PSR-4](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md) autoloading standard.
+
+### DocBlocks
+
+`@param` tags should **not be aligned** and arguments should be separated by **2 spaces**. Here's an example block
+
+
+    /**
+     * Register a binding with the container.
+     *
+     * @param  string|array  $abstract
+     * @param  \Closure|string|null  $concrete
+     * @param  bool  $shared
+     * @return void
+     */
+    public function bind($abstract, $concrete = null, $shared = false)
+    {
+      // …
+    }
+


### PR DESCRIPTION
Doesn't seem to be any info on docblocks, yet there does appear to be an expectation from the Laravel team.
